### PR TITLE
fix: do not disable modal cancel button

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -60,7 +60,7 @@ export class Modal extends React.Component<ModalProps> {
             <Button isDanger={isDanger} disabled={disabled} onClick={this.submit}>
               { submitBtnTxt }
             </Button>
-            { cancellable && <Button isSecondary isDanger={isDanger} disabled={disabled} onClick={this.close} aria-label="Close">
+            { cancellable && <Button isSecondary isDanger={isDanger} onClick={this.close} aria-label="Close">
               Cancel
             </Button> }
           </footer>


### PR DESCRIPTION
When `disabled` flag is passed to `Modal`, disable only the "Save" button, not the "Cancel" button. Clicking on the X triggers `this.props.onCancel()` just the same as clicking on "Cancel", and it doesn't make sense to disable the "Cancel" button as well. 

## Before
![before](https://user-images.githubusercontent.com/3076787/97486183-558ac780-1918-11eb-8d65-885aa6f15cdd.png)

## After
![after](https://user-images.githubusercontent.com/3076787/97485831-dd240680-1917-11eb-938a-f920afffecb0.png)
